### PR TITLE
fix: compile error on windows platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Inspired by [overseer](https://github.com/jpillora/overseer) and [endless](https://github.com/fvbock/endless), with minimum codes and handy api to make http server graceful.
 
 # Prerequisite
-golang 1.8+
+- golang 1.8+
+- linux/darwin(windows not supported)
 
 # Feature
 - Graceful reload http servers, zero downtime on upgrade.

--- a/graceful.go
+++ b/graceful.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package graceful
 
 import (

--- a/graceful_test.go
+++ b/graceful_test.go
@@ -1,0 +1,12 @@
+package graceful
+
+import (
+	"testing"
+)
+
+func TestNewServer(t *testing.T) {
+	s := NewServer()
+	if s == nil {
+		t.Errorf("NewServer return nil")
+	}
+}

--- a/graceful_windows.go
+++ b/graceful_windows.go
@@ -1,0 +1,54 @@
+// +build windows
+
+package graceful
+
+import (
+	"net/http"
+	"time"
+)
+
+// address defines addr as well as its network type
+type address struct {
+	addr    string // ip:port, unix path
+	network string // tcp, unix
+}
+
+type option struct {
+	watchInterval time.Duration
+	stopTimeout   time.Duration
+}
+
+type Server struct {
+	opt      *option
+	addrs    []address
+	handlers []http.Handler
+}
+
+func NewServer(opts ...option) *Server {
+	panic("platform windows unsupported")
+	return nil
+}
+
+func (s *Server) Register(addr string, handler http.Handler) {
+}
+
+func (s *Server) RegisterUnix(addr string, handler http.Handler) {
+}
+
+func (s *Server) Run() error {
+	panic("platform windows unsupported")
+	return nil
+}
+
+func IsMaster() bool {
+	return true
+}
+
+func IsWorker() bool {
+	return false
+}
+
+func ListenAndServe(addr string, handler http.Handler) error {
+	panic("platform windows unsupported")
+	return nil
+}

--- a/master.go
+++ b/master.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package graceful
 
 import (

--- a/worker.go
+++ b/worker.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package graceful
 
 import (


### PR DESCRIPTION
Adding cross platform file to avoid compliation error on windows.
However, graceful reload is not supported this time and we raise a panic instead.

Change-Id: I176041ed769a438bec95211a97bff59c1fa23431