### PR TITLE
fix: workers always exit while their parent pid is 1

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -14,6 +14,7 @@ const (
 	EnvWorker       = "GRACEFUL_WORKER"
 	EnvNumFD        = "GRACEFUL_NUMFD"
 	EnvOldWorkerPid = "GRACEFUL_OLD_WORKER_PID"
+	EnvParentPid    = "GRACEFUL_PARENT_PID"
 	ValWorker       = "1"
 )
 

--- a/master.go
+++ b/master.go
@@ -179,7 +179,7 @@ func (m *master) forkWorker() (int, error) {
 		args = os.Args[1:]
 	}
 
-	env := append(os.Environ(), fmt.Sprintf("%s=%s", EnvWorker, ValWorker), fmt.Sprintf("%s=%d", EnvNumFD, len(m.extraFiles)), fmt.Sprintf("%s=%d", EnvOldWorkerPid, m.workerPid))
+	env := append(os.Environ(), fmt.Sprintf("%s=%s", EnvWorker, ValWorker), fmt.Sprintf("%s=%d", EnvNumFD, len(m.extraFiles)), fmt.Sprintf("%s=%d", EnvParentPid, os.Getpid()), fmt.Sprintf("%s=%d", EnvOldWorkerPid, m.workerPid))
 
 	cmd := exec.Command(path, args...)
 	cmd.Stdout = os.Stdout

--- a/worker.go
+++ b/worker.go
@@ -113,9 +113,10 @@ func (w *worker) startServers() error {
 
 // watchMaster to monitor if master dead
 func (w *worker) watchMaster() error {
+	masterPid := os.Getenv(EnvParentPid)
 	for {
 		// if parent id change to 1, it means parent is dead
-		if os.Getppid() == 1 {
+		if !processExist(masterPid) {
 			log.Printf("master dead, stop worker\n")
 			w.stop()
 			break
@@ -124,6 +125,15 @@ func (w *worker) watchMaster() error {
 	}
 	w.stopCh <- struct{}{}
 	return nil
+}
+
+func processExist(pid string) bool {
+	Pid, _ := strconv.ParseInt(pid, 10, 64)
+	if err := syscall.Kill(int(Pid), 0); err != nil {
+		log.Printf("kill err: %v", err)
+		return false
+	}
+	return true
 }
 
 func (w *worker) waitSignal() {


### PR DESCRIPTION
In some situation (such as kubernetes container), the
master's pid is 1. So it is not right to use "ppid==1"
to justice whether master is dead.

In my PR, I use an environment to record master pid,
and use syscall.Kill(0) to check whether master is dead